### PR TITLE
TULAP branding: navy theme, header wordmark, page title

### DIFF
--- a/src/assets/images/tulap-logo.svg
+++ b/src/assets/images/tulap-logo.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="168" height="40" viewBox="0 0 168 40" fill="none" role="img" aria-label="TULAP">
+  <rect x="0" y="4" width="32" height="32" rx="5" fill="#003366"/>
+  <rect x="6" y="11" width="20" height="4" rx="1" fill="#ffffff"/>
+  <rect x="6" y="18" width="20" height="4" rx="1" fill="#ffffff"/>
+  <rect x="6" y="25" width="11" height="4" rx="1" fill="#ffffff"/>
+  <text x="42" y="29" font-family="Nunito, 'Segoe UI', Arial, sans-serif" font-size="26" font-weight="800" letter-spacing="0.5" fill="#003366">TULAP</text>
+</svg>

--- a/src/index.html
+++ b/src/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8">
   <base href="/">
-  <title>DSpace</title>
+  <title>TULAP — Turkish Language Processing Platform</title>
   <meta name="viewport" content="width=device-width,minimum-scale=1">
   <meta http-equiv="cache-control" content="no-store">
 </head>

--- a/src/themes/dspace/app/header/header.component.html
+++ b/src/themes/dspace/app/header/header.component.html
@@ -6,7 +6,7 @@
       [attr.aria-label]="(isMobile$ | async) ? ('nav.main.description' | translate) : null"
          class="h-100 flex-fill d-flex flex-row flex-nowrap justify-content-start align-items-center gapx-3 flex-grow-1">
       <a class="d-block my-2 my-md-0" routerLink="/home" [attr.aria-label]="'home.title' | translate" role="button" tabindex="0">
-        <img id="header-logo" src="assets/images/dspace-logo.svg" [attr.alt]="'menu.header.image.logo' | translate"/>
+        <img id="header-logo" src="assets/images/tulap-logo.svg" [attr.alt]="'menu.header.image.logo' | translate"/>
       </a>
       @if ((isMobile$ | async) !== true) {
         <nav class="navbar navbar-expand p-0 align-items-stretch align-self-stretch flex-grow-1 flex-shrink-1" id="desktop-navbar" [attr.aria-label]="'nav.main.description' | translate">

--- a/src/themes/dspace/app/home-page/home-news/home-news.component.ts
+++ b/src/themes/dspace/app/home-page/home-news/home-news.component.ts
@@ -1,5 +1,5 @@
-import { TranslateModule } from '@ngx-translate/core';
 import { Component } from '@angular/core';
+import { TranslateModule } from '@ngx-translate/core';
 
 import { HomeNewsComponent as BaseComponent } from '../../../../../app/home-page/home-news/home-news.component';
 

--- a/src/themes/dspace/app/home-page/home-news/home-news.component.ts
+++ b/src/themes/dspace/app/home-page/home-news/home-news.component.ts
@@ -7,7 +7,9 @@ import { HomeNewsComponent as BaseComponent } from '../../../../../app/home-page
   selector: 'ds-themed-home-news',
   styleUrls: ['./home-news.component.scss'],
   templateUrl: './home-news.component.html',
-  imports: [TranslateModule],
+  imports: [
+    TranslateModule,
+  ],
 })
 
 /**

--- a/src/themes/dspace/styles/_theme_sass_variable_overrides.scss
+++ b/src/themes/dspace/styles/_theme_sass_variable_overrides.scss
@@ -45,7 +45,7 @@ $font-family-sans-serif: 'Nunito', -apple-system, BlinkMacSystemFont, "Segoe UI"
 //$cyan:    #17a2b8 !default;
 
 // Override semantic colors here
-$primary:   #43515f;  // Gray
+$primary:   #003366;  // TULAP navy (TABILAB brand)
 $secondary: #495057;  // As Bootstrap $gray-700
 $success:   #92c642;  // Lime
 $info:      #1e6f90;  // Light blue


### PR DESCRIPTION
First branding increment toward the TULAP visual identity (TABILAB navy #003366).

## Changes
- **Primary color** `#43515f` (gray) → **`#003366`** (TABILAB navy)
- **Header logo** `dspace-logo.svg` → **TULAP wordmark** `assets/images/tulap-logo.svg`
- **Page title** `DSpace` → **`TULAP — Turkish Language Processing Platform`**

## Already branded (no change)
Home page (TULAP banner + tagline + demos link), favicon, Turkish/English i18n.

## Follow-ups
- Footer still shows DSpace/LYRASIS boilerplate — needs a theme footer override.
- Swap in an official TULAP logo image if one exists (currently a text wordmark).

> ⚠️ Draft — needs a frontend build to verify visually before merge.