### PR TITLE
feat(theme): TULAP-branded footer

### DIFF
--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -1963,6 +1963,12 @@
 
   "footer.copyright": "copyright © 2002-{{ year }}",
 
+  "footer.tulap.title": "TULAP — Turkish Language Processing Platform",
+
+  "footer.tulap.org": "Boğaziçi University · TABILAB",
+
+  "footer.powered-by": "Powered by DSpace",
+
   "footer.link.accessibility": "Accessibility settings",
 
   "footer.link.dspace": "DSpace software",

--- a/src/assets/i18n/tr.json5
+++ b/src/assets/i18n/tr.json5
@@ -3433,6 +3433,12 @@
   // "footer.copyright": "copyright © 2002-{{ year }}",
   "footer.copyright": "telif hakkı © 2002-{{ year }}",
 
+  "footer.tulap.title": "TULAP — Türkçe Dil İşleme Platformu",
+
+  "footer.tulap.org": "Boğaziçi Üniversitesi · TABILAB",
+
+  "footer.powered-by": "DSpace ile geliştirilmiştir",
+
   // "footer.link.accessibility": "Accessibility settings",
   // TODO New key - Add a translation
   "footer.link.accessibility": "Accessibility settings",

--- a/src/themes/dspace/app/footer/footer.component.html
+++ b/src/themes/dspace/app/footer/footer.component.html
@@ -1,0 +1,58 @@
+<footer>
+  <!-- Copyright -->
+  <div class="bottom-footer p-1 d-flex flex-column flex-md-row justify-content-center align-items-center text-white">
+    <div class="content-container align-self-center text-center">
+      <p class="m-0">
+        <span class="tulap-attribution">{{ 'footer.tulap.title' | translate }}</span>
+        <span class="d-none d-md-inline"> · </span>
+        <br class="d-md-none" />
+        {{ 'footer.copyright' | translate:{year: dateObj | date:'y'} }} {{ 'footer.tulap.org' | translate }}
+        <span class="d-none d-md-inline"> · </span>
+        <br class="d-md-none" />
+        <a class="text-white powered-by"
+           href="https://dspace.org/" target="_blank" rel="noopener noreferrer"
+           role="link" tabindex="0">{{ 'footer.powered-by' | translate }}</a>
+      </p>
+      <ul class="footer-info list-unstyled d-flex justify-content-center flex-wrap mb-0">
+        @if (showCookieSettings) {
+          <li>
+            <button class="btn btn-link text-white" type="button" (click)="openCookieSettings()" role="button" tabindex="0">
+              {{ 'footer.link.cookies' | translate }}
+            </button>
+          </li>
+        }
+        <li>
+          <a class="btn text-white"
+             routerLink="info/accessibility" role="link" tabindex="0">{{ 'footer.link.accessibility' | translate }}</a>
+        </li>
+        @if (showPrivacyPolicy) {
+          <li>
+            <a class="btn text-white"
+               routerLink="info/privacy" role="link" tabindex="0">{{ 'footer.link.privacy-policy' | translate }}</a>
+          </li>
+        }
+        @if (showEndUserAgreement) {
+          <li>
+            <a class="btn text-white"
+               routerLink="info/end-user-agreement" role="link" tabindex="0">{{ 'footer.link.end-user-agreement' | translate }}</a>
+          </li>
+        }
+        @if (showSendFeedback$ | async) {
+          <li>
+            <a class="btn text-white"
+               routerLink="info/feedback" role="link" tabindex="0">{{ 'footer.link.feedback' | translate }}</a>
+          </li>
+        }
+      </ul>
+    </div>
+    @if (coarLdnEnabled$ | async) {
+      <div class="notify-enabled text-white align-self-end">
+        <a class="coar-notify-support-route" routerLink="info/coar-notify-support" role="link" tabindex="0">
+          <img class="n-coar" src="assets/images/n-coar.svg" [attr.alt]="'menu.header.image.logo' | translate" />
+          {{ 'footer.link.coar-notify-support' | translate }}
+        </a>
+      </div>
+    }
+  </div>
+  <!-- Copyright -->
+</footer>

--- a/src/themes/dspace/app/footer/footer.component.scss
+++ b/src/themes/dspace/app/footer/footer.component.scss
@@ -1,0 +1,77 @@
+:host {
+  footer {
+    background-color: var(--ds-footer-bg);
+    text-align: center;
+    z-index: var(--ds-footer-z-index);
+    border-top: var(--ds-footer-border);
+    padding: var(--ds-footer-padding);
+
+    p {
+      margin: 0;
+    }
+
+    .tulap-attribution {
+      font-weight: 600;
+    }
+
+    .powered-by {
+      opacity: 0.85;
+      font-size: .875em;
+    }
+
+    .bottom-footer {
+      .notify-enabled {
+        position: relative;
+        margin-top: 4px;
+
+        .coar-notify-support-route {
+          padding: 0 calc(var(--bs-spacer) / 2);
+          color: inherit;
+        }
+
+        .n-coar {
+          height: var(--ds-footer-n-coar-height);
+          margin-bottom: 8.5px;
+        }
+
+        @media screen and (min-width: map-get($grid-breakpoints, md)) {
+          position: absolute;
+          bottom: 4px;
+          right: 0;
+        }
+      }
+
+      ul {
+        li {
+          display: inline-flex;
+
+          a, .btn-link {
+            padding: 0 calc(var(--bs-spacer) / 2);
+            color: inherit;
+            font-size: .875em;
+
+            &:focus {
+              box-shadow: none;
+              text-decoration: underline;
+            }
+
+            &:focus-visible {
+              box-shadow: 0 0 0 0.2rem rgba(255, 255, 255, 0.5);
+            }
+          }
+
+          &:not(:last-child) {
+            &:after {
+              content: '';
+              border-right: 1px var(--bs-secondary) solid;
+            }
+          }
+        }
+      }
+    }
+
+    .btn {
+      box-shadow: none;
+    }
+  }
+}

--- a/src/themes/dspace/app/footer/footer.component.ts
+++ b/src/themes/dspace/app/footer/footer.component.ts
@@ -1,0 +1,28 @@
+import {
+  AsyncPipe,
+  DatePipe,
+} from '@angular/common';
+import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { TranslateModule } from '@ngx-translate/core';
+
+import { FooterComponent as BaseComponent } from '../../../../app/footer/footer.component';
+
+/**
+ * TULAP-branded footer (Boğaziçi University · TABILAB).
+ * Overrides the base DSpace footer to replace the DSpace/LYRASIS boilerplate
+ * with TULAP attribution while keeping a "Powered by DSpace" credit.
+ */
+@Component({
+  selector: 'ds-themed-footer',
+  styleUrls: ['footer.component.scss'],
+  templateUrl: 'footer.component.html',
+  imports: [
+    AsyncPipe,
+    DatePipe,
+    RouterLink,
+    TranslateModule,
+  ],
+})
+export class FooterComponent extends BaseComponent {
+}

--- a/src/themes/dspace/eager-theme.module.ts
+++ b/src/themes/dspace/eager-theme.module.ts
@@ -2,6 +2,7 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
 import { RootModule } from '../../app/root.module';
+import { FooterComponent } from './app/footer/footer.component';
 import { HeaderComponent } from './app/header/header.component';
 import { HeaderNavbarWrapperComponent } from './app/header-nav-wrapper/header-navbar-wrapper.component';
 import { HomeNewsComponent } from './app/home-page/home-news/home-news.component';
@@ -16,6 +17,7 @@ const ENTRY_COMPONENTS = [];
 const DECLARATIONS = [
   ...ENTRY_COMPONENTS,
   HomeNewsComponent,
+  FooterComponent,
   HeaderComponent,
   HeaderNavbarWrapperComponent,
   NavbarComponent,


### PR DESCRIPTION
## What

The active `dspace` theme didn't override the footer, so the site rendered the **base DSpace footer**: a "Lorem ipsum" placeholder top block + DSpace software / LYRASIS copyright links.

This adds a footer override under the `dspace` theme that:

- removes the placeholder top-footer entirely
- replaces the DSpace/LYRASIS copyright line with TULAP attribution: **"TULAP — Turkish Language Processing Platform · Boğaziçi University · TABILAB"**
- keeps a small **"Powered by DSpace"** credit (links to dspace.org)
- preserves all functional links (accessibility, privacy, end-user agreement, feedback, cookie settings, COAR Notify)

New i18n keys (en + tr): `footer.tulap.title`, `footer.tulap.org`, `footer.powered-by`.

## Notes

- **Logo:** the official TULAP brand is the plain **"TULAP" text wordmark** (per the intended home-page design), so the existing header wordmark is kept as-is — no graphical logo is introduced.
- Validated locally: eslint clean on the new `.ts` and `.html`; both i18n JSON5 files parse with the new keys present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)