### PR TITLE
fix(a11y): underline in-text 'demos' link on homepage

### DIFF
--- a/src/themes/dspace/app/home-page/home-news/home-news.component.html
+++ b/src/themes/dspace/app/home-page/home-news/home-news.component.html
@@ -8,7 +8,7 @@
             {{ 'home.description.lead' | translate }}
           </p>
           <p>
-            You can try out the <a href="/demo">demos</a> of all tools whose source code and dockerized versions are also made available.
+            You can try out the <a href="/demo" class="text-decoration-underline">demos</a> of all tools whose source code and dockerized versions are also made available.
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- The homepage's "You can try out the demos of all tools..." paragraph has a link (`demos`) styled the same color as surrounding text, distinguished only by an underline that Bootstrap 5 removes by default from links inside running text. This trips the axe-core `link-in-text-block` (WCAG 1.4.1 "Use of Color") rule.
- Adds `class="text-decoration-underline"` to the `<a href="/demo">` link in `home-news.component.html` to restore a non-color distinguishing cue.

## Verification
- This is the **only** e2e failure present on `main` right now — confirmed by inspecting recent `main` CI runs (e.g. run 28464965025): `Homepage should pass accessibility tests` fails identically on both Node 20.x and 22.x with `AssertionError: 1 accessibility violation was detected: expected 1 to equal 0`, and the failure aborts the job before the SSR-verify steps ever run.
- Manually dispatched the full `build.yml` workflow (`workflow_dispatch`) against this branch to get complete verification before merging, since PR-triggered runs skip e2e/SSR: run [28470061093](https://github.com/BOUN-TABILab-TULAP/tulap-dspace-angular/actions/runs/28470061093).
  - `tests (20.x)`: ✓ passing (lint, build, unit tests, full e2e suite, all SSR-verify steps)
  - `tests (22.x)`: ✓ passing (same)
  - `codecov`: ✗ fails on an unrelated `Wandalen/wretry.action` internal error (`Expects non-primitive`) — this is a pre-existing, code-unrelated action bug, not a test failure.

## Test plan
- [x] Full e2e + SSR-verify suite green on both Node 20.x and 22.x via manual workflow dispatch
- [x] Lint clean