### PR TITLE
ci: don't let codecov upload crash redden the nightly Build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -362,6 +362,10 @@ jobs:
       # Retry action: https://github.com/marketplace/actions/retry-action
       # Codecov action: https://github.com/codecov/codecov-action
       - name: Upload coverage to Codecov.io
+        # Best-effort only (no CODECOV_TOKEN on this fork): don't let a crash in the
+        # wrapper/upload action itself (e.g. "Expects non-primitive") redden the whole
+        # nightly run — fail_ci_if_error only covers upload-reported errors, not that.
+        continue-on-error: true
         uses: Wandalen/wretry.action@v1.3.0
         with:
           action: codecov/codecov-action@v4


### PR DESCRIPTION
## Summary
- The nightly scheduled `Build` workflow has failed every run since 2026-07-02, but the actual `tests (20.x)`/`tests (22.x)` jobs pass — only the `codecov` job's upload step crashes (`Expects non-primitive`), a wrapper/action-level failure that `fail_ci_if_error: false` doesn't catch.
- This fork has no `CODECOV_TOKEN` configured, so the upload was already best-effort only.
- Marks the upload step `continue-on-error: true` so a broken/flaky third-party action can't flip the whole workflow red.

## Test plan
- [x] Confirms `tests` jobs already pass on `main` (not touched by this change)
- [ ] Next scheduled/triggered run shows `codecov` step failing but job/workflow overall green