### PR TITLE
ci: don't let a codecov-upload crash redden the nightly Build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -362,6 +362,10 @@ jobs:
       # Retry action: https://github.com/marketplace/actions/retry-action
       # Codecov action: https://github.com/codecov/codecov-action
       - name: Upload coverage to Codecov.io
+        # Best-effort only (no CODECOV_TOKEN on this fork): don't let a crash in the
+        # wrapper/upload action itself (e.g. "Expects non-primitive") redden the whole
+        # nightly run — fail_ci_if_error only covers upload-reported errors, not that.
+        continue-on-error: true
         uses: Wandalen/wretry.action@v1.3.0
         with:
           action: codecov/codecov-action@v4


### PR DESCRIPTION
The `Wandalen/wretry.action` wrapper around `codecov-action@v4` has been crashing outright ("Expects non-primitive") on every scheduled run since 2026-07-02, turning the whole nightly Build red even when build+tests pass. `fail_ci_if_error` only covers upload-reported errors, not a crash in the action itself, so it never applied.

This fork has no `CODECOV_TOKEN` (the upload is best-effort only), so this marks just that step `continue-on-error: true` instead of gating the workflow's status on it. 4-line change to `.github/workflows/build.yml`.