### PR TITLE
ci: build+push TULAP UI image to GHCR on tulap-* tags

### DIFF
--- a/.github/workflows/tulap-image.yml
+++ b/.github/workflows/tulap-image.yml
@@ -1,0 +1,37 @@
+# Builds the TULAP DSpace UI production image and pushes it to GHCR.
+# Deploys consume this image (nlp-tools-platform/dspace compose pins a tag)
+# instead of building from a source checkout on the server — see the TULAP
+# git strategy / fork policy (machines wiki).
+name: TULAP UI image
+
+on:
+  push:
+    tags: ['tulap-*']
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Resolve image tag
+        id: tag
+        run: echo "tag=${GITHUB_REF_NAME:-manual-$(date +%Y%m%d)}" >> "$GITHUB_OUTPUT"
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.dist
+          push: true
+          tags: ghcr.io/boun-tabilab-tulap/tulap-dspace-angular:${{ steps.tag.outputs.tag }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
Part of the TULAP git strategy: deploys consume a GHCR image pinned by tag in nlp-tools-platform's dspace compose, replacing the source checkout on the nlp server. Trigger: push a `tulap-*` tag (or manual dispatch). Uses `Dockerfile.dist` and the built-in `GITHUB_TOKEN` (packages:write).